### PR TITLE
Add random secret generation

### DIFF
--- a/bin/deploy.js
+++ b/bin/deploy.js
@@ -1,39 +1,130 @@
-const { CloudFormation } = require("@aws-sdk/client-cloudformation");
-const fs = require("fs");
-const readline = require('readline');
+#! /usr/bin/env node
+import yargs from "yargs";
+import chalk from "chalk";
 
+import {
+  CloudFormation,
+  RegistrationStatus,
+} from "@aws-sdk/client-cloudformation";
+import fs from "fs";
+import util from "util";
+import readline from "readline";
+import cryptoRandomString from "crypto-random-string";
+
+const tinkerPurple = chalk.rgb(99, 102, 241);
+
+const awsRegions = [
+  "us-east-1",
+  "us-east-2",
+  "us-west-1",
+  "us-west-2",
+  "af-south-1",
+  "ap-east-1",
+  "ap-south-1",
+  "ap-northeast-2",
+  "ap-southeast-1",
+  "ap-southeast-2",
+  "ap-northeast-1",
+  "ca-central-1",
+  "eu-central-1",
+  "eu-west-1",
+  "eu-west-2",
+  "eu-west-3",
+  "eu-north-1",
+  "me-south-1",
+  "sa-east-1",
+];
+
+const stackName = "TinkerAdminStack";
+const minSecretLength = 35;
 const templatePath = "./tinker_admin_template.json";
+const encoding = "utf8";
 
 const rl = readline.createInterface({
   input: process.stdin,
   output: process.stdout,
 });
 
-// TODO: Change to promises instead of callbacks?
+const readFileAsync = util.promisify(fs.readFile);
 
-rl.question("Enter the region: ", (region) => {
-  const cloudformation = new CloudFormation({ region });
+const readTemplateFromFile = async (templatePath, encoding) => {
+  try {
+    let template = await readFileAsync(templatePath, encoding);
+    return template;
+  } catch (error) {
+    console.error(chalk.red("Error reading template file:"), error);
+    rl.close();
+    process.exit(1);
+  }
+};
 
-  fs.readFile(templatePath, "utf8", (err, template) => {
-    if (err) {
-      console.error("Error reading template file:", err);
-      rl.close();
-      process.exit(1);
-    }
+const promisifyRegionQuestion = () => {
+  return new Promise((resolve, reject) => {
+    rl.question(tinkerPurple("Enter the region: "), (answer) => {
+      if (!awsRegions.includes(answer)) {
+        reject(chalk.red("Invalid region"));
+      }
 
-    const stackParams = {
-      StackName: "TinkerAdminStack",
-      TemplateBody: template,
-    };
+      resolve(answer);
+    });
+  });
+};
 
-    cloudformation.createStack(stackParams, (err, data) => {
-      if (err) {
-        console.error("Error creating stack:", err);
-        process.exit(1);
+const askRegion = async () => {
+  try {
+    let region = await promisifyRegionQuestion();
+    return region;
+  } catch (error) {
+    console.error(error);
+    rl.close();
+    process.exit(1);
+  }
+};
+
+const promisifyCreateStack = async (cloudFormation, stackParams) => {
+  return new Promise((resolve, reject) => {
+    cloudFormation.createStack(stackParams, (error, data) => {
+      if (error) {
+        reject(error);
       } else {
-        console.log("Stack creation initiated:", data.StackId);
-        process.exit(0);
+        resolve(data);
       }
     });
   });
+};
+
+const createStack = async (cloudFormation, stackParams) => {
+  try {
+    const data = await promisifyCreateStack(cloudFormation, stackParams);
+    console.log(tinkerPurple("Stack creation initiated:"), data.StackId);
+    process.exit(0);
+  } catch (err) {
+    console.error(chalk.red("Error creating stack:"), err);
+    process.exit(1);
+  }
+};
+
+let template = await readTemplateFromFile(templatePath, encoding);
+let region = await askRegion();
+
+let secret = cryptoRandomString({
+  length: minSecretLength,
+  type: "alphanumeric",
 });
+
+console.log(tinkerPurple("Your secret is"), secret);
+
+const cloudFormation = new CloudFormation({ region });
+
+const stackParams = {
+  StackName: stackName,
+  TemplateBody: template,
+  Parameters: [
+    {
+      ParameterKey: "Secret",
+      ParameterValue: secret,
+    },
+  ],
+};
+
+await createStack(cloudFormation, stackParams);

--- a/bin/index.js
+++ b/bin/index.js
@@ -1,8 +1,5 @@
 #! /usr/bin/env node
-const yargs = require("yargs");
+import yargs from "yargs";
+import chalk from 'chalk';
 
-console.log("Welcome to Tinker!");
-console.log("Please enter AWS credentials");
-console.log("Email:");
-console.log("Password:");
-console.log("email and password saved to ~/.aws/credentials");
+console.log(chalk.magenta("Welcome to Tinker!"));

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,12 +5,15 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "tinker-cli",
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
         "@aws-sdk/client-cloudformation": "^3.362.0",
         "aws-sdk": "^2.1406.0",
         "aws-sdk-js-codemod": "^0.14.1",
+        "chalk": "^5.3.0",
+        "crypto-random-string": "^5.0.0",
         "yargs": "^17.7.2"
       },
       "bin": {
@@ -1441,6 +1444,19 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/highlight/node_modules/chalk": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+      "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+      "dependencies": {
+        "ansi-styles": "^3.2.1",
+        "escape-string-regexp": "^1.0.5",
+        "supports-color": "^5.3.0"
+      },
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/@babel/parser": {
@@ -3184,16 +3200,14 @@
       ]
     },
     "node_modules/chalk": {
-      "version": "2.4.2",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-      "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-      "dependencies": {
-        "ansi-styles": "^3.2.1",
-        "escape-string-regexp": "^1.0.5",
-        "supports-color": "^5.3.0"
-      },
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.3.0.tgz",
+      "integrity": "sha512-dLitG79d+GV1Nb/VYcCDFivJeK1hiukt9QjRNVOsUtTy1rR1YJsmpGGTZ3qJos+uw7WmWF4wUwBd9jxjocFC2w==",
       "engines": {
-        "node": ">=4"
+        "node": "^12.17.0 || ^14.13 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
     "node_modules/cliui": {
@@ -3261,6 +3275,20 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/core-js"
+      }
+    },
+    "node_modules/crypto-random-string": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/crypto-random-string/-/crypto-random-string-5.0.0.tgz",
+      "integrity": "sha512-KWjTXWwxFd6a94m5CdRGW/t82Tr8DoBc9dNnPCAbFI1EBweN6v1tv8y4Y1m7ndkp/nkIBRxUxAzpaBnR2k3bcQ==",
+      "dependencies": {
+        "type-fest": "^2.12.2"
+      },
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/debug": {
@@ -4288,6 +4316,17 @@
       "version": "2.6.0",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.0.tgz",
       "integrity": "sha512-7At1WUettjcSRHXCyYtTselblcHl9PJFFVKiCAy/bY97+BPZXSQ2wbq0P9s8tK2G7dFQfNnlJnPAiArVBVBsfA=="
+    },
+    "node_modules/type-fest": {
+      "version": "2.19.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
+      "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==",
+      "engines": {
+        "node": ">=12.20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/unicode-canonical-property-names-ecmascript": {
       "version": "2.0.0",
@@ -5684,6 +5723,18 @@
         "@babel/helper-validator-identifier": "^7.22.5",
         "chalk": "^2.0.0",
         "js-tokens": "^4.0.0"
+      },
+      "dependencies": {
+        "chalk": {
+          "version": "2.4.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+          "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+          "requires": {
+            "ansi-styles": "^3.2.1",
+            "escape-string-regexp": "^1.0.5",
+            "supports-color": "^5.3.0"
+          }
+        }
       }
     },
     "@babel/parser": {
@@ -6849,14 +6900,9 @@
       "integrity": "sha512-2uDDk+TRiTX5hMcUYT/7CSyzMZxjfGu0vAUjS2g0LSD8UoXOv0LtpH4LxGMemsiPq6LCVIUjNwVM0erkOkGCDA=="
     },
     "chalk": {
-      "version": "2.4.2",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-      "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-      "requires": {
-        "ansi-styles": "^3.2.1",
-        "escape-string-regexp": "^1.0.5",
-        "supports-color": "^5.3.0"
-      }
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.3.0.tgz",
+      "integrity": "sha512-dLitG79d+GV1Nb/VYcCDFivJeK1hiukt9QjRNVOsUtTy1rR1YJsmpGGTZ3qJos+uw7WmWF4wUwBd9jxjocFC2w=="
     },
     "cliui": {
       "version": "8.0.1",
@@ -6913,6 +6959,14 @@
       "peer": true,
       "requires": {
         "browserslist": "^4.21.5"
+      }
+    },
+    "crypto-random-string": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/crypto-random-string/-/crypto-random-string-5.0.0.tgz",
+      "integrity": "sha512-KWjTXWwxFd6a94m5CdRGW/t82Tr8DoBc9dNnPCAbFI1EBweN6v1tv8y4Y1m7ndkp/nkIBRxUxAzpaBnR2k3bcQ==",
+      "requires": {
+        "type-fest": "^2.12.2"
       }
     },
     "debug": {
@@ -7647,6 +7701,11 @@
       "version": "2.6.0",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.0.tgz",
       "integrity": "sha512-7At1WUettjcSRHXCyYtTselblcHl9PJFFVKiCAy/bY97+BPZXSQ2wbq0P9s8tK2G7dFQfNnlJnPAiArVBVBsfA=="
+    },
+    "type-fest": {
+      "version": "2.19.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
+      "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA=="
     },
     "unicode-canonical-property-names-ecmascript": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -20,10 +20,13 @@
     "@aws-sdk/client-cloudformation": "^3.362.0",
     "aws-sdk": "^2.1406.0",
     "aws-sdk-js-codemod": "^0.14.1",
+    "chalk": "^5.3.0",
+    "crypto-random-string": "^5.0.0",
     "yargs": "^17.7.2"
   },
   "bin": {
     "tinker-init": "./bin/index.js",
     "tinker-deploy": "./bin/deploy.js"
-  }
+  },
+  "type": "module"
 }

--- a/tinker_admin_template.json
+++ b/tinker_admin_template.json
@@ -10,6 +10,11 @@
       "Description": "Name for the CloudFormation stack"
     },
 
+    "Secret": {
+      "Type": "String",
+      "Description": "For PostgREST to mint and authenticate JWTs. Also required for user sign up into the Admin app."
+    },
+
     "InstanceType": {
       "Description": "WebServer EC2 instance type",
       "Type": "String",


### PR DESCRIPTION
Change from CommonJS to ESM modules, because chalk package uses ESM.
Refactor from async callbacks to promises to avoid deep callback nesting.
Randomly generate the secret instead of asking the user for it, so we have one less user validation to account for.